### PR TITLE
Add placeholder tests and instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,20 @@
 # General-Lottery-Dapp
+
+This repository contains the skeleton of a lottery dApp. Tests are located under the `contracts/test` and `backend/test` directories.
+
+## Running Tests
+
+1. Install dependencies:
+   ```
+   npm install
+   ```
+2. Run Hardhat (smart contract) tests:
+   ```
+   npx hardhat test
+   ```
+3. Run backend tests:
+   ```
+   npm test
+   ```
+
+These commands assume you have Node.js and Hardhat installed locally.

--- a/backend/test/api.test.js
+++ b/backend/test/api.test.js
@@ -1,0 +1,33 @@
+const chai = require('chai');
+const chaiHttp = require('chai-http');
+const expect = chai.expect;
+
+chai.use(chaiHttp);
+
+// Placeholder for express app
+const app = require('../app');
+// Placeholder for database instance
+const db = require('../db');
+
+describe('API', function () {
+  before(async function () {
+    // Initialize database connection
+    await db.connect();
+  });
+
+  after(async function () {
+    await db.disconnect();
+  });
+
+  it('responds to GET /tickets', async function () {
+    const res = await chai.request(app).get('/tickets');
+    expect(res).to.have.status(200);
+    expect(res.body).to.be.an('array');
+  });
+
+  it('inserts a ticket into the database', async function () {
+    const ticket = { player: '0x0', numbers: [1,2,3] };
+    const result = await db.insertTicket(ticket);
+    expect(result.insertedId).to.exist;
+  });
+});

--- a/contracts/test/lottery.test.js
+++ b/contracts/test/lottery.test.js
@@ -1,0 +1,43 @@
+const { expect } = require("chai");
+
+// Placeholder Lottery contract interface
+const Lottery = artifacts.require("Lottery");
+
+describe("Lottery", function () {
+  let lottery;
+  let accounts;
+
+  beforeEach(async function () {
+    accounts = await web3.eth.getAccounts();
+    // Assume Lottery is already deployed
+    lottery = await Lottery.deployed();
+  });
+
+  it("should not allow buying more than the max tickets", async function () {
+    const maxTickets = await lottery.maxTickets();
+    try {
+      for (let i = 0; i <= maxTickets.toNumber(); i++) {
+        await lottery.buyTicket({ from: accounts[0], value: web3.utils.toWei("1", "ether") });
+      }
+      expect.fail("Expected error not received");
+    } catch (err) {
+      expect(err.message).to.contain("Max tickets reached");
+    }
+  });
+
+  it("distributes fees correctly", async function () {
+    const feePercent = await lottery.feePercent();
+    const potBefore = await lottery.pot();
+    await lottery.buyTicket({ from: accounts[1], value: web3.utils.toWei("1", "ether") });
+    const potAfter = await lottery.pot();
+    const expectedPot = potBefore.add(web3.utils.toBN(web3.utils.toWei("1", "ether")).mul(web3.utils.toBN(100 - feePercent)).div(web3.utils.toBN(100)));
+    expect(potAfter.toString()).to.equal(expectedPot.toString());
+  });
+
+  it("pays the winner", async function () {
+    await lottery.buyTicket({ from: accounts[2], value: web3.utils.toWei("1", "ether") });
+    await lottery.pickWinner({ from: accounts[0] });
+    const winner = await lottery.lastWinner();
+    expect(winner).to.not.equal("0x0000000000000000000000000000000000000000");
+  });
+});


### PR DESCRIPTION
## Summary
- create skeleton smart contract tests in `contracts/test/lottery.test.js`
- add backend tests in `backend/test/api.test.js`
- expand README with instructions on running the tests

## Testing
- `npx hardhat test` *(fails: 403 Forbidden)*
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_685ca469ef7c83319ebc93fdd9ba7d7d