### PR TITLE
Add backend with web3 integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,15 @@
-# General-Lottery-Dapp
+# General Lottery Dapp
+
+This repository contains a basic backend implementation for managing lottery rounds.
+
+## Backend Setup
+
+1. Navigate to the `backend` folder.
+2. Install dependencies with `npm install`.
+3. Configure environment variables in a `.env` file:
+   - `MONGODB_URI` – MongoDB connection string.
+   - `WEB3_PROVIDER` – URL of the Ethereum node.
+   - `CONTRACT_ADDRESS` – Deployed lottery contract address.
+4. Start the server with `npm start`.
+
+The backend exposes endpoints under `/round` for starting a round, closing a round, and retrieving round status.

--- a/backend/config/db.js
+++ b/backend/config/db.js
@@ -1,0 +1,11 @@
+const mongoose = require('mongoose');
+
+const connectDB = async () => {
+  const uri = process.env.MONGODB_URI || 'mongodb://localhost:27017/lottery';
+  await mongoose.connect(uri, {
+    useNewUrlParser: true,
+    useUnifiedTopology: true,
+  });
+};
+
+module.exports = connectDB;

--- a/backend/config/web3.js
+++ b/backend/config/web3.js
@@ -1,0 +1,6 @@
+const Web3 = require('web3');
+
+const providerURL = process.env.WEB3_PROVIDER || 'http://localhost:8545';
+const web3 = new Web3(providerURL);
+
+module.exports = web3;

--- a/backend/index.js
+++ b/backend/index.js
@@ -1,0 +1,22 @@
+require('dotenv').config();
+const express = require('express');
+const bodyParser = require('body-parser');
+const connectDB = require('./config/db');
+
+const roundRoutes = require('./routes/round');
+
+const app = express();
+app.use(bodyParser.json());
+
+connectDB().then(() => {
+  console.log('Database connected');
+}).catch(err => {
+  console.error('DB connection failed', err);
+});
+
+app.use('/round', roundRoutes);
+
+const PORT = process.env.PORT || 3000;
+app.listen(PORT, () => {
+  console.log(`Server running on port ${PORT}`);
+});

--- a/backend/models/Participant.js
+++ b/backend/models/Participant.js
@@ -1,0 +1,9 @@
+const mongoose = require('mongoose');
+
+const participantSchema = new mongoose.Schema({
+  address: { type: String, required: true },
+  roundNumber: { type: Number, required: true },
+  joinedAt: { type: Date, default: Date.now }
+});
+
+module.exports = mongoose.model('Participant', participantSchema);

--- a/backend/models/Round.js
+++ b/backend/models/Round.js
@@ -1,0 +1,12 @@
+const mongoose = require('mongoose');
+
+const roundSchema = new mongoose.Schema({
+  roundNumber: { type: Number, required: true },
+  isActive: { type: Boolean, default: true },
+  participants: [{ type: String }], // wallet addresses
+  winner: { type: String },
+  startedAt: { type: Date, default: Date.now },
+  endedAt: { type: Date }
+});
+
+module.exports = mongoose.model('Round', roundSchema);

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "lottery-backend",
+  "version": "1.0.0",
+  "main": "index.js",
+  "scripts": {
+    "start": "node index.js"
+  },
+  "dependencies": {
+    "express": "^4.18.2",
+    "mongoose": "^7.0.0",
+    "web3": "^1.9.0",
+    "dotenv": "^16.0.0"
+  }
+}

--- a/backend/routes/round.js
+++ b/backend/routes/round.js
@@ -1,0 +1,67 @@
+const express = require('express');
+const router = express.Router();
+const Round = require('../models/Round');
+const Participant = require('../models/Participant');
+const web3 = require('../config/web3');
+
+// Example contract ABI and address (placeholders)
+const contractABI = [];
+const contractAddress = process.env.CONTRACT_ADDRESS || '0x0';
+const contract = new web3.eth.Contract(contractABI, contractAddress);
+
+// Start a new round
+router.post('/start', async (req, res) => {
+  try {
+    const { roundNumber } = req.body;
+
+    // Call smart contract to start round
+    const accounts = await web3.eth.getAccounts();
+    await contract.methods.startRound(roundNumber).send({ from: accounts[0] });
+
+    // Save round to database
+    const round = new Round({ roundNumber });
+    await round.save();
+
+    res.json({ message: 'Round started', round });
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: 'Failed to start round' });
+  }
+});
+
+// Close a round
+router.post('/close', async (req, res) => {
+  try {
+    const { roundNumber } = req.body;
+
+    const accounts = await web3.eth.getAccounts();
+    const tx = await contract.methods.closeRound(roundNumber).send({ from: accounts[0] });
+
+    const round = await Round.findOneAndUpdate(
+      { roundNumber },
+      { isActive: false, endedAt: new Date() },
+      { new: true }
+    );
+
+    res.json({ message: 'Round closed', round, tx });
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: 'Failed to close round' });
+  }
+});
+
+// Get current status
+router.get('/status/:roundNumber', async (req, res) => {
+  try {
+    const { roundNumber } = req.params;
+    const round = await Round.findOne({ roundNumber });
+    if (!round) return res.status(404).json({ error: 'Round not found' });
+
+    res.json({ round });
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: 'Failed to retrieve status' });
+  }
+});
+
+module.exports = router;


### PR DESCRIPTION
## Summary
- set up Express backend with MongoDB and Web3 connection
- add Round and Participant models
- implement `/round` endpoints to start, close and view status
- document backend usage in README

## Testing
- `node --version`
- `npm --version`


------
https://chatgpt.com/codex/tasks/task_e_685ca465da6c8331937da1d79d866a02